### PR TITLE
Adds a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,30 @@
 FROM ubuntu:16.04
 
 RUN apt-get update
-# NOTE: To provide support for testing sftp locally
-# RUN apt-get install openssh-client openssh-server -y
-# TODO: In /etc/ssh/sshd_config change 'PermitRootLogin prohibit-password' to 'PermitRootLogin yes'
-# RUN echo "Docker!" | passwd --stdin root
+
+# Local Development
+#
+#   To provide support for testing sftp locally the openssh-server is required
+#   and it needs to be configured to allow root to login with a password
+#   and to ensure that the root user has a password that is known
+#
+#   NOTE: `service ssh start` still needs to be executed upon entrance
+#
+RUN apt-get install openssh-server -y
+RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN echo "root:ubuntu" | chpasswd
+
+# Application Dependencies
+RUN apt-get install openssh-client 
 RUN apt-get install python2.7 python-pip -y
 RUN pip install requests python-dateutil pysftp
 RUN apt-get install sox libsox-fmt-all -y
 
+# Local Developmnet
+#
+#    Create a path in the image, declare it as a volume, and then make it
+#    the default place to work.
+#
 RUN mkdir -p /share
 VOLUME ["/share"]
 WORKDIR /share

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+
+RUN apt-get update
+# NOTE: To provide support for testing sftp locally
+# RUN apt-get install openssh-client openssh-server -y
+# TODO: In /etc/ssh/sshd_config change 'PermitRootLogin prohibit-password' to 'PermitRootLogin yes'
+# RUN echo "Docker!" | passwd --stdin root
+RUN apt-get install python2.7 python-pip -y
+RUN pip install requests python-dateutil pysftp
+RUN apt-get install sox libsox-fmt-all -y
+
+RUN mkdir -p /share
+VOLUME ["/share"]
+WORKDIR /share

--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ The code for the python client of the Spinitron API is already included in this 
 	* `archiveSource`: in original use case this folder is NFS mounted
 * create a cronjob using ` example-cronjob.txt` as a model
 
+## Local Development
+
+A Dockerfile is found within this repository to create a Docker Image that attempts to match the environment that this code will execute. To create this image run:
+
+```bash
+$ docker build -t autocharlie .
+```
+
+This names the Docker image *autocharlie*. To verify it was created you can ask docker to show you all the images it has in its registry:
+
+```bash
+$ docker images
+REPOSITORY                            TAG                 IMAGE ID            CREATED             SIZE
+autocharlie                           latest              45a374402e85        6 minutes ago       184MB
+<none>                                <none>              0c03edf1150e        9 minutes ago       156MB
+<none>                                <none>              cc9cfab99677        13 minutes ago      118MB
+habitat/default-studio-x86_64-linux   0.78.0              f24a730e974b        9 days ago          416MB
+ubuntu                                16.04               9361ce633ff1        10 days ago         118MB
+```
+
+The image enables you to create containers. To create a container workspace that mounts your current filesystem run:
+
+```bash
+$ docker run -it -v /Users/franklinwebber/src/autocharlie:/share autocharlie /bin/bash
+```
 ## Tests
 No test coverage :(
 


### PR DESCRIPTION
To create a local dev environment that is close to the stations environment a Dockerfile is useful for creating a Docker image which can create Docker containers. It's not complete as it does not fully automate setting up the ssh-server completely.

Another good thing is that it captures all the dependencies. I found out the hard way that I needed a pip to install a few modules.